### PR TITLE
Demonstrating LBM Solver

### DIFF
--- a/BOLT/src/Grid.cpp
+++ b/BOLT/src/Grid.cpp
@@ -148,7 +148,7 @@ void GridClass::lbmKernel() {
 	for (int i = 0; i < Nx; i++) {
 		for (int j = 0; j < Ny; j++) {
 
-			int id = i * Nx + j;
+			int id = i * Ny + j;
 
 			streamCollide(i, j, id);
 
@@ -364,4 +364,8 @@ std::vector<int> GridClass::getNormalVector(int i, int j, eDirectionType &normal
 	}
 
 	return normalVector;
+}
+
+void GridClass::solver() {
+	lbmKernel();
 }

--- a/BOLT/src/main.cpp
+++ b/BOLT/src/main.cpp
@@ -4,4 +4,8 @@ int main() {
 	std::cout << "BOLT: LBM Simulator" << std::endl;
 
 	GridClass grid;
+
+	grid.solver();
+
+	std::cout << "Iteration run succesfully..." << std::endl;
 }


### PR DESCRIPTION
Implementation of ```GridClass::solver()``` as a public method allows for access to the ```GridClass::lbmKernel()``` method. Calling the solver method within ```main.cpp``` demonstrates that the code runs without faults.

Resolves: #22