### PR TITLE
Included ability to time

### DIFF
--- a/BOLT/include/Grid.h
+++ b/BOLT/include/Grid.h
@@ -50,6 +50,10 @@ private:
 	// Other
 	std::vector<double> u_in;               // Inlet velocity profile
 
+	// Timings
+	std::chrono::time_point<std::chrono::steady_clock> startTime;   // Time when clock is called
+	std::chrono::duration<double> loopTime;                         // Average loop time
+
 public:
 
 	// LBM Methods

--- a/BOLT/include/input.h
+++ b/BOLT/include/input.h
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <vector>
 #include <numeric>
+#include <chrono>
 
 // Set resolution
 const int resolution = 1;

--- a/BOLT/src/Grid.cpp
+++ b/BOLT/src/Grid.cpp
@@ -295,11 +295,16 @@ void GridClass::writeInfo() {
 	// Calculate maxRe
 	double maxRe = (maxVel * Dx / Dt) * ref_L / ref_nu;
 
+	// Calculate timings
+	loopTime = std::chrono::steady_clock::now() - startTime;
+	loopTime /= t;
+
 	// Output values
 	std::cout << std::endl << std::endl;
 	
 	std::cout << "Time step " << t << " of " << nSteps << std::endl;
 	std::cout << "Simulation has done " << t * Dt << " of " << nSteps * Dt << " seconds" << std::endl;
+	std::cout << "MLUPS = " << Nx * Ny / (1000000.0 * loopTime.count()) << std::endl;
 
 	std::cout << "Max Velocity = " << maxVel << std::endl;
 	std::cout << "Max Velocity (m/s) = " << maxVel * Dx / Dt << std::endl;
@@ -474,6 +479,10 @@ GridClass::GridClass() {
 	Dt = (nu / nu_p) * SQ(Dx);
 	Dm = (rho_p / rho0) * CU(Dx);
 	Drho = (rho_p / rho0);
+
+	// Set timings
+	startTime = std::chrono::steady_clock::now();
+	// loopTime = 0.0;
 
 	// Set array size and initialise
 	u.resize(Nx * Ny * dims, 0.0);


### PR DESCRIPTION
Introduction of ability to time allows for MLUPS to be displayed - this is a good performance metric that can be used to compare the performance of the simulator in different compute environments.

Resolves: #26