### PR TITLE
Implemented ObjectsClass::objectKernel()

### DIFF
--- a/BOLT/src/Objects.cpp
+++ b/BOLT/src/Objects.cpp
@@ -1,6 +1,12 @@
 // Includes
 #include "../include/Objects.h"
 
+void ObjectsClass::objectKernel() {
+
+    // At the moment only considering IBM.
+    ibmKernel();
+}
+
 void ObjectsClass::ibmKernel() {
 
     fill(gridPtr->force_ibm.begin(), gridPtr->force_ibm.begin(), 0.0);


### PR DESCRIPTION
At the moment the ```ObjectsClass::objectKernel()``` is only taking the IBM into account as as such only needs to run ```ObjectsClass::ibmKernel()```

Resolves: #68